### PR TITLE
Add Lefthook config, git hooks, AGENTS.md, and commit layout validation.

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+ROOT="$(git rev-parse --show-toplevel)"
+exec python3 "$ROOT/scripts/validate-commit-msg.py" "$1"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+ROOT="$(git rev-parse --show-toplevel)"
+exec sh "$ROOT/scripts/verify-go.sh"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+ROOT="$(git rev-parse --show-toplevel)"
+exec sh "$ROOT/scripts/verify-go.sh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent and contributor notes
+
+## Git hooks
+
+Hooks match CI (see `.github/workflows/go.yml`): `go build -v ./...` and `go test -v ./...`, plus a `commit-msg` check for the format below.
+
+Git runs `scripts/verify-go.sh` from `.githooks/` (same commands as CI). [Lefthook](https://github.com/evilmartians/lefthook) is configured in `lefthook.yml` if you want to run the same checks manually, for example `lefthook run pre-commit` after `go install github.com/evilmartians/lefthook@latest`.
+
+After cloning, wire git to the committed hooks once:
+
+```sh
+./scripts/install-git-hooks.sh
+```
+
+`pre-commit` and `pre-push` run build and tests. `commit-msg` checks the format below. Use `git commit --no-verify` or `git push --no-verify` only when you fully intend to skip checks (avoid for normal PRs).
+
+## Commit messages
+
+Write the subject/summary as **up to 80 words** (not more). Then **one blank line**. Then **one paragraph** with a direct, no-fluff description of what changed and why it matters—no bullet lists in the body, no marketing filler, and no second paragraph.
+
+Example:
+
+```
+Add Lefthook and a commit-msg check so local commits match CI and AGENTS.md layout.
+
+Hooks run go build and go test before commit and push; the Python script enforces summary length and a single body paragraph so history stays scannable.
+```
+
+Merge commits and lines beginning with `fixup!` or `squash!` are not validated.
+
+After the body paragraph you may add optional Git-style trailers in separate paragraphs (each line `Key: value`), for example `Co-authored-by:` or editor-added `Made-with:` lines—no additional prose paragraphs after the first body block.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# https://github.com/evilmartians/lefthook
+# Optional: go install github.com/evilmartians/lefthook@latest
+# Git uses .githooks/ (see scripts/install-git-hooks.sh); those scripts call lefthook when available.
+pre-commit:
+  commands:
+    verify:
+      run: sh scripts/verify-go.sh
+
+pre-push:
+  commands:
+    verify:
+      run: sh scripts/verify-go.sh
+
+commit-msg:
+  commands:
+    message-format:
+      run: python3 scripts/validate-commit-msg.py {1}

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# Point git at the repo's hook scripts (committed .githooks/).
+set -eu
+root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Run this from inside the jorb git repository." >&2
+  exit 1
+}
+cd "$root"
+git config core.hooksPath .githooks
+echo "git core.hooksPath is now .githooks (relative to repo root)."

--- a/scripts/validate-commit-msg.py
+++ b/scripts/validate-commit-msg.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Enforce AGENTS.md commit layout: summary (<=80 words), blank line, one body paragraph."""
+import re
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: validate-commit-msg.py <path-to-commit-message-file>", file=sys.stderr)
+        return 2
+    path = sys.argv[1]
+    raw = open(path, encoding="utf-8", errors="replace").read()
+    lines = [ln for ln in raw.splitlines() if not ln.lstrip().startswith("#")]
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    text = "\n".join(lines)
+    if not text.strip():
+        return 0
+
+    first = text.split("\n", 1)[0]
+    if first.startswith("Merge ") or first.startswith("fixup!") or first.startswith("squash!"):
+        return 0
+
+    parts = text.split("\n\n")
+    if len(parts) < 2:
+        print(
+            "Commit message must have a summary, a blank line, then one body paragraph "
+            "(see AGENTS.md).",
+            file=sys.stderr,
+        )
+        return 1
+    summary = parts[0]
+    body = parts[1]
+    trailer_line = re.compile(r"^[\w-]+: .+$")
+    for extra in parts[2:]:
+        if not extra.strip():
+            continue
+        for line in extra.splitlines():
+            if not line.strip():
+                print(
+                    "Extra content after the body must be Git-style trailers only "
+                    "(e.g. Co-authored-by), one line per paragraph.",
+                    file=sys.stderr,
+                )
+                return 1
+            if not trailer_line.match(line.strip()):
+                print(
+                    "Only one prose paragraph is allowed after the summary; remove extra "
+                    "paragraphs or express them as key: value trailers.",
+                    file=sys.stderr,
+                )
+                return 1
+    summary_words = len(summary.split())
+    if summary_words > 80:
+        print(f"Summary must be at most 80 words (got {summary_words}).", file=sys.stderr)
+        return 1
+    if not body.strip():
+        print("Body paragraph must be non-empty.", file=sys.stderr)
+        return 1
+    if re.search(r"\n\s*\n", body):
+        print("Body must be a single paragraph (no blank lines inside the body).", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-go.sh
+++ b/scripts/verify-go.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# Same checks as .github/workflows/go.yml
+set -eu
+cd "$(dirname "$0")/.."
+go build -v ./...
+go test -v ./...


### PR DESCRIPTION
Hooks use scripts/verify-go.sh to match CI; install-git-hooks.sh sets core.hooksPath to .githooks; lefthook.yml mirrors the same checks for optional manual runs; validate-commit-msg.py enforces a summary of at most eighty words, one body paragraph, and allows standard Git trailers after the body.

Made-with: Cursor