### PR TITLE
Add per-state Timeout that bounds each Exec attempt and routes the job to a configured FailState when the deadline expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ The rate limiter automatically:
 - Increases on success (+1 per increase interval while under max)
 - Stays within configured min/max bounds (initial/min/max are normalized, including `min > max` and non-positive inputs)
 
+## Per-State Timeout
+
+Set `State.Timeout` to bound how long a single `Exec` invocation may run. When the deadline expires the worker routes the job to a configured `FailState` and records a `"timed out after <duration>"` entry in the job's `StateErrors`. The timeout applies per attempt, so a state that re-enqueues itself for retry receives a fresh window each time:
+
+```go
+states := []jorb.State[AC, OC, JC]{
+    {
+        TriggerState: "fetch",
+        Exec:         fetch,
+        Concurrency:  10,
+        Timeout: &jorb.Timeout{
+            Duration:  30 * time.Second,
+            FailState: "fetch-failed",
+        },
+    },
+    {TriggerState: "fetch-failed", Terminal: true},
+    {TriggerState: "done", Terminal: true},
+}
+```
+
+A nil `Timeout` (the default) disables the deadline. `NewProcessor` rejects misconfigured timeouts at construction: zero/negative `Duration`, missing `FailState`, a `FailState` that is not in the registered state set, or a `Timeout` declared on a terminal state.
+
+Outer cancellation of the context passed to `Processor.Exec` (for example, a Ctrl-C of the host process) is **not** reclassified as a timeout. The worker only routes to `FailState` when its own deadline elapses and the parent context is still healthy; otherwise the original error propagates so callers can distinguish operator-driven shutdown from a stuck job.
+
 # Concepts
 
 When making a program you basically need the following: AC, OC, JC, Job, Run, States, StatusListener, persistence (`JsonSerializer` or `NilSerializer`), and a Processor
@@ -115,6 +139,7 @@ A State is a description of a possible state that a job can be in, a state has:
 is terminal to patch up workflows or to stop certain actions (I turn terminal off in off hours so I don't send actual CRs, just all the pre-validation). flag.Bool works great for this.
 * Concurrency: the number of concurrent procesors for this state, this is nice if the steps take a while esp on network calls
 * RateLimit: a rate.Limit that is shared by all processors for this state, great if you are hitting a rate limited api
+* Timeout: an optional `*Timeout` that bounds how long a single Exec invocation may run; on expiry the job routes to the configured FailState (see [Per-State Timeout](#per-state-timeout))
 
 Typically you want to be pretty granular with your steps. For instance in a recent workflow I have seperate states for:
 * File modification

--- a/processor.go
+++ b/processor.go
@@ -112,7 +112,14 @@ func newStateStorageFromStates[AC any, OC any, JC any](states []State[AC, OC, JC
 			State:    stateName,
 			Terminal: s.Terminal,
 		}
-		st.stateChan[stateName] = make(chan Job[JC], s.Concurrency)
+		// Clamp the channel buffer to a non-negative size so a misconfigured
+		// State (negative Concurrency) doesn't panic make(chan, n) before the
+		// subsequent validate() pass surfaces the configuration error.
+		bufSize := s.Concurrency
+		if bufSize < 0 {
+			bufSize = 0
+		}
+		st.stateChan[stateName] = make(chan Job[JC], bufSize)
 	}
 
 	sort.Strings(st.sortedStateNames)
@@ -448,79 +455,115 @@ func (s *StateExec[AC, OC, JC]) Run() {
 		case <-s.ctx.Done():
 			return
 		case j, more := <-s.jobChan:
-			// The channel was closed
 			if !more {
 				return
 			}
-
-			// Job is passed by value but StateErrors is a map: clone so we don't race persistence reading r.Jobs.
-			j.StateErrors = cloneStateErrorsMap(j.StateErrors)
-
-			if s.state.RateLimit != nil {
-				s.state.RateLimit.Wait(s.ctx)
-				slog.Info("LimiterAllowed", "worker", s.i, "state", s.state.TriggerState, "job", j.Id)
-			}
-			priorState := j.State
-			// Execute the job
-			rtn := Return[JC]{
-				PriorState: priorState,
-			}
-			slog.Info("Executing job", "job", j.Id, "state", s.state.TriggerState)
-
-			// Apply per-attempt Timeout if configured. The cancel must fire
-			// regardless of whether the deadline elapsed, so it is scoped to a
-			// closure that runs once per job.
-			execCtx := s.ctx
-			var cancel context.CancelFunc
-			if s.state.Timeout != nil {
-				execCtx, cancel = context.WithTimeout(s.ctx, s.state.Timeout.Duration)
-			}
-			var err error
-			j.C, j.State, rtn.KickRequests, err = s.state.Exec(execCtx, s.ac, s.oc, j.C)
-			if cancel != nil {
-				cancel()
-			}
-
-			// Distinguish our deadline from outer cancellation: only reclassify
-			// when the parent context is still healthy. Otherwise the user
-			// killed the run and the original error should propagate.
-			timedOut := s.state.Timeout != nil && errors.Is(err, context.DeadlineExceeded) && s.ctx.Err() == nil
-			if timedOut {
-				j.StateErrors[priorState] = append(j.StateErrors[priorState],
-					fmt.Sprintf("timed out after %s", s.state.Timeout.Duration))
-				j.State = s.state.Timeout.FailState
-				err = nil
-				slog.Info("Execution timed out", "job", j.Id, "state", s.state.TriggerState, "newState", j.State, "duration", s.state.Timeout.Duration)
-			} else if err != nil {
-				j.StateErrors[priorState] = append(j.StateErrors[priorState], err.Error())
-
-				// Handle rate limit errors with backoff
-				if IsRateLimitError(err) {
-					if backoff, ok := s.state.RateLimit.(BackoffRateLimiter); ok {
-						backoff.Backoff()
-					} else if s.state.RateLimit != nil {
-						slog.Debug("RateLimitError but RateLimit does not implement BackoffRateLimiter; adaptive backoff skipped",
-							"state", s.state.TriggerState)
-					}
-				}
-
-				slog.Info("Execution complete", "job", j.Id, "state", s.state.TriggerState, "newState", j.State, "error", err, "kickRequests", len(rtn.KickRequests))
-			} else {
-				// On success, increase rate if using adaptive rate limiter
-				if backoff, ok := s.state.RateLimit.(BackoffRateLimiter); ok {
-					backoff.OnSuccess()
-				}
-				slog.Info("Execution complete", "job", j.Id, "state", s.state.TriggerState, "newState", j.State, "kickRequests", len(rtn.KickRequests))
-			}
-
-			rtn.Job = j
-			slog.Info("Returning job", "job", j.Id, "newState", j.State)
+			rtn := s.executeOne(j)
+			slog.Info("Returning job", "job", rtn.Job.Id, "newState", rtn.Job.State)
 			if s.ctx.Err() != nil {
 				return
 			}
 			s.returnChan <- rtn
-			slog.Info("Returned job", "job", j.Id, "newState", j.State)
+			slog.Info("Returned job", "job", rtn.Job.Id, "newState", rtn.Job.State)
 		}
+	}
+}
+
+// executeOne handles one job end-to-end: rate-limit gate, deadline-wrapped
+// Exec, and result classification (timeout / error / success). The returned
+// Return is ready to send on the processor's return channel.
+func (s *StateExec[AC, OC, JC]) executeOne(j Job[JC]) Return[JC] {
+	// Job is passed by value but StateErrors is a map: clone so we don't race
+	// persistence reading r.Jobs.
+	j.StateErrors = cloneStateErrorsMap(j.StateErrors)
+
+	s.applyRateLimit(j.Id)
+
+	priorState := j.State
+	rtn := Return[JC]{PriorState: priorState}
+	slog.Info("Executing job", "job", j.Id, "state", s.state.TriggerState)
+
+	execCtx, cancel := s.deriveExecContext()
+	var err error
+	j.C, j.State, rtn.KickRequests, err = s.state.Exec(execCtx, s.ac, s.oc, j.C)
+	cancel()
+
+	s.classifyResult(&j, err, priorState, len(rtn.KickRequests))
+	rtn.Job = j
+	return rtn
+}
+
+// applyRateLimit blocks on the configured rate limiter, if any, until a token
+// is available. Logs the unblock event for traceability when a limiter is set.
+// No-op when RateLimit is nil.
+func (s *StateExec[AC, OC, JC]) applyRateLimit(jobID string) {
+	if s.state.RateLimit == nil {
+		return
+	}
+	s.state.RateLimit.Wait(s.ctx)
+	slog.Info("LimiterAllowed", "worker", s.i, "state", s.state.TriggerState, "job", jobID)
+}
+
+// deriveExecContext returns the context to pass to Exec along with a cancel
+// function the caller MUST call. When Timeout is configured the context carries
+// a deadline; otherwise the worker context is returned with a no-op cancel so
+// callers can always invoke cancel without a nil check.
+func (s *StateExec[AC, OC, JC]) deriveExecContext() (context.Context, context.CancelFunc) {
+	if s.state.Timeout == nil {
+		return s.ctx, func() {}
+	}
+	return context.WithTimeout(s.ctx, s.state.Timeout.Duration)
+}
+
+// classifyResult mutates j in place based on the outcome of Exec: a deadline
+// expiry triggers a Timeout-driven transition to FailState, a generic error is
+// recorded against priorState (with optional AIMD backoff), and a success
+// triggers AIMD additive-increase. priorState is the state Exec was invoked
+// from; kickCount is included in slog metadata.
+func (s *StateExec[AC, OC, JC]) classifyResult(j *Job[JC], err error, priorState string, kickCount int) {
+	// Distinguish our deadline from outer cancellation: only reclassify when
+	// the parent context is still healthy. Otherwise the user killed the run
+	// and the original error should propagate.
+	if s.state.Timeout != nil && errors.Is(err, context.DeadlineExceeded) && s.ctx.Err() == nil {
+		j.StateErrors[priorState] = append(j.StateErrors[priorState],
+			fmt.Sprintf("timed out after %s", s.state.Timeout.Duration))
+		j.State = s.state.Timeout.FailState
+		slog.Info("Execution timed out", "job", j.Id, "state", s.state.TriggerState, "newState", j.State, "duration", s.state.Timeout.Duration)
+		return
+	}
+	if err != nil {
+		j.StateErrors[priorState] = append(j.StateErrors[priorState], err.Error())
+		s.applyRateLimitErrorBackoff(err)
+		slog.Info("Execution complete", "job", j.Id, "state", s.state.TriggerState, "newState", j.State, "error", err, "kickRequests", kickCount)
+		return
+	}
+	s.applyRateLimitSuccess()
+	slog.Info("Execution complete", "job", j.Id, "state", s.state.TriggerState, "newState", j.State, "kickRequests", kickCount)
+}
+
+// applyRateLimitErrorBackoff applies an AIMD multiplicative-decrease step when
+// err is a RateLimitError and the configured limiter implements
+// BackoffRateLimiter. When a RateLimitError surfaces against a non-adaptive
+// limiter the signal is logged at debug since it has no actionable target.
+func (s *StateExec[AC, OC, JC]) applyRateLimitErrorBackoff(err error) {
+	if !IsRateLimitError(err) {
+		return
+	}
+	if backoff, ok := s.state.RateLimit.(BackoffRateLimiter); ok {
+		backoff.Backoff()
+		return
+	}
+	if s.state.RateLimit != nil {
+		slog.Debug("RateLimitError but RateLimit does not implement BackoffRateLimiter; adaptive backoff skipped",
+			"state", s.state.TriggerState)
+	}
+}
+
+// applyRateLimitSuccess applies an AIMD additive-increase step on a successful
+// Exec when the limiter is adaptive. No-op for non-adaptive or absent limiters.
+func (s *StateExec[AC, OC, JC]) applyRateLimitSuccess() {
+	if backoff, ok := s.state.RateLimit.(BackoffRateLimiter); ok {
+		backoff.OnSuccess()
 	}
 }
 

--- a/processor.go
+++ b/processor.go
@@ -27,7 +27,9 @@ type RateLimiter interface {
 // applies per attempt; a state that re-enqueues itself for retry receives a
 // fresh window on each invocation. Outer cancellation of the Processor's
 // context propagates as the original error and does not get reclassified as a
-// timeout. A nil Timeout (default) disables the deadline. Set on State.Timeout.
+// timeout. A nil Timeout (default) disables the deadline. Setting Timeout on a
+// terminal State is permitted but inert: terminal states never invoke Exec, so
+// the deadline never fires. Set on State.Timeout.
 type Timeout struct {
 	// Duration is the deadline applied to each Exec call. Must be positive.
 	Duration time.Duration
@@ -141,9 +143,10 @@ func (s stateStorage[AC, OC, JC]) validate() error {
 			if state.Concurrency < 0 {
 				return fmt.Errorf("terminal state %s has negative concurrency", state.TriggerState)
 			}
-			if state.Timeout != nil {
-				return fmt.Errorf("terminal state %s cannot define a Timeout (no Exec runs)", state.TriggerState)
-			}
+			// Timeout on a terminal state is permitted but inert: terminal
+			// states never invoke Exec, so the deadline never fires. Allowed
+			// so callers can flip a state's Terminal flag during iteration
+			// without having to also strip its Timeout.
 		} else {
 			if state.Concurrency < 1 {
 				return fmt.Errorf("non-terminal state %s has non-positive concurrency", state.TriggerState)

--- a/processor.go
+++ b/processor.go
@@ -114,9 +114,6 @@ func newStateStorageFromStates[AC any, OC any, JC any](states []State[AC, OC, JC
 			State:    stateName,
 			Terminal: s.Terminal,
 		}
-		// Clamp the channel buffer to a non-negative size so a misconfigured
-		// State (negative Concurrency) doesn't panic make(chan, n) before the
-		// subsequent validate() pass surfaces the configuration error.
 		bufSize := s.Concurrency
 		if bufSize < 0 {
 			bufSize = 0
@@ -143,10 +140,6 @@ func (s stateStorage[AC, OC, JC]) validate() error {
 			if state.Concurrency < 0 {
 				return fmt.Errorf("terminal state %s has negative concurrency", state.TriggerState)
 			}
-			// Timeout on a terminal state is permitted but inert: terminal
-			// states never invoke Exec, so the deadline never fires. Allowed
-			// so callers can flip a state's Terminal flag during iteration
-			// without having to also strip its Timeout.
 		} else {
 			if state.Concurrency < 1 {
 				return fmt.Errorf("non-terminal state %s has non-positive concurrency", state.TriggerState)

--- a/processor.go
+++ b/processor.go
@@ -2,12 +2,14 @@ package jorb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
 	"runtime/pprof"
 	"sort"
 	"sync"
+	"time"
 )
 
 const (
@@ -17,6 +19,21 @@ const (
 // RateLimiter is an interface for rate limiting
 type RateLimiter interface {
 	Wait(ctx context.Context) error
+}
+
+// Timeout caps the wall-clock duration of a single Exec invocation for a State.
+// When the deadline expires the worker routes the job to FailState and records
+// a "timed out after <duration>" entry in the job's StateErrors. The timeout
+// applies per attempt; a state that re-enqueues itself for retry receives a
+// fresh window on each invocation. Outer cancellation of the Processor's
+// context propagates as the original error and does not get reclassified as a
+// timeout. A nil Timeout (default) disables the deadline. Set on State.Timeout.
+type Timeout struct {
+	// Duration is the deadline applied to each Exec call. Must be positive.
+	Duration time.Duration
+	// FailState is the state to transition the job into when the deadline
+	// expires. Must be a registered state in the Processor's state set.
+	FailState string
 }
 
 // State represents a state in a state machine for job processing.
@@ -41,6 +58,12 @@ type State[AC any, OC any, JC any] struct {
 
 	// RateLimit is an optional rate limiter for controlling the execution rate of this state. Useful when calling rate limited apis.
 	RateLimit RateLimiter
+
+	// Timeout optionally bounds how long a single Exec invocation may run.
+	// When nil (default) Exec runs without a deadline. When non-nil the
+	// processor wraps the per-job context with WithTimeout(Duration) and
+	// routes the job to FailState if the deadline expires. See [Timeout].
+	Timeout *Timeout
 }
 
 // KickRequest struct is a job context with a requested state that the
@@ -111,12 +134,26 @@ func (s stateStorage[AC, OC, JC]) validate() error {
 			if state.Concurrency < 0 {
 				return fmt.Errorf("terminal state %s has negative concurrency", state.TriggerState)
 			}
+			if state.Timeout != nil {
+				return fmt.Errorf("terminal state %s cannot define a Timeout (no Exec runs)", state.TriggerState)
+			}
 		} else {
 			if state.Concurrency < 1 {
 				return fmt.Errorf("non-terminal state %s has non-positive concurrency", state.TriggerState)
 			}
 			if state.Exec == nil {
 				return fmt.Errorf("non-terminal state %s but has no Exec function", state.TriggerState)
+			}
+		}
+		if state.Timeout != nil {
+			if state.Timeout.Duration <= 0 {
+				return fmt.Errorf("state %s: Timeout.Duration must be positive, got %s", state.TriggerState, state.Timeout.Duration)
+			}
+			if state.Timeout.FailState == "" {
+				return fmt.Errorf("state %s: Timeout requires a FailState", state.TriggerState)
+			}
+			if _, ok := s.stateMap[state.Timeout.FailState]; !ok {
+				return fmt.Errorf("state %s: Timeout.FailState %q is not a registered state", state.TriggerState, state.Timeout.FailState)
 			}
 		}
 	}
@@ -429,9 +466,32 @@ func (s *StateExec[AC, OC, JC]) Run() {
 				PriorState: priorState,
 			}
 			slog.Info("Executing job", "job", j.Id, "state", s.state.TriggerState)
+
+			// Apply per-attempt Timeout if configured. The cancel must fire
+			// regardless of whether the deadline elapsed, so it is scoped to a
+			// closure that runs once per job.
+			execCtx := s.ctx
+			var cancel context.CancelFunc
+			if s.state.Timeout != nil {
+				execCtx, cancel = context.WithTimeout(s.ctx, s.state.Timeout.Duration)
+			}
 			var err error
-			j.C, j.State, rtn.KickRequests, err = s.state.Exec(s.ctx, s.ac, s.oc, j.C)
-			if err != nil {
+			j.C, j.State, rtn.KickRequests, err = s.state.Exec(execCtx, s.ac, s.oc, j.C)
+			if cancel != nil {
+				cancel()
+			}
+
+			// Distinguish our deadline from outer cancellation: only reclassify
+			// when the parent context is still healthy. Otherwise the user
+			// killed the run and the original error should propagate.
+			timedOut := s.state.Timeout != nil && errors.Is(err, context.DeadlineExceeded) && s.ctx.Err() == nil
+			if timedOut {
+				j.StateErrors[priorState] = append(j.StateErrors[priorState],
+					fmt.Sprintf("timed out after %s", s.state.Timeout.Duration))
+				j.State = s.state.Timeout.FailState
+				err = nil
+				slog.Info("Execution timed out", "job", j.Id, "state", s.state.TriggerState, "newState", j.State, "duration", s.state.Timeout.Duration)
+			} else if err != nil {
 				j.StateErrors[priorState] = append(j.StateErrors[priorState], err.Error())
 
 				// Handle rate limit errors with backoff

--- a/processor_test.go
+++ b/processor_test.go
@@ -1634,11 +1634,71 @@ func TestTimeout_RetryGetsFreshWindow(t *testing.T) {
 	mu.Unlock()
 }
 
-// TestTimeout_ValidationRejectsBadConfig confirms that NewProcessor refuses to
-// construct a state machine with a malformed Timeout: zero/negative duration,
-// missing FailState, FailState referencing an unregistered state, or Timeout
-// declared on a terminal state.
-func TestTimeout_ValidationRejectsBadConfig(t *testing.T) {
+// TestTimeout_RecordsErrorOnTriggeringState verifies that when Timeout fires
+// from a non-NEW state, the "timed out after" entry is appended to
+// StateErrors keyed on the *triggering* state, not always TRIGGER_STATE_NEW.
+// The pipeline routes NEW → STATE_MIDDLE (Timeout fires here) → STATE_DONE_TWO.
+func TestTimeout_RecordsErrorOnTriggeringState(t *testing.T) {
+	t.Parallel()
+
+	// First state hops the job into STATE_MIDDLE without exhausting any deadline.
+	hop := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
+		return jc, STATE_MIDDLE, nil, nil
+	}
+	// Middle state holds the Timeout and runs slow enough to trip it.
+	slow := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
+		select {
+		case <-time.After(2 * time.Second):
+			return jc, STATE_DONE, nil, nil
+		case <-ctx.Done():
+			return jc, "", nil, ctx.Err()
+		}
+	}
+
+	states := []State[MyAppContext, MyOverallContext, MyJobContext]{
+		{TriggerState: TRIGGER_STATE_NEW, Exec: hop, Concurrency: 1},
+		{
+			TriggerState: STATE_MIDDLE,
+			Exec:         slow,
+			Concurrency:  1,
+			Timeout: &Timeout{
+				Duration:  50 * time.Millisecond,
+				FailState: STATE_DONE_TWO,
+			},
+		},
+		{TriggerState: STATE_DONE, Terminal: true},
+		{TriggerState: STATE_DONE_TWO, Terminal: true},
+	}
+
+	r := NewRun[MyOverallContext, MyJobContext]("timeout-records-on-triggering-state", MyOverallContext{})
+	r.AddJob(MyJobContext{})
+
+	p, err := NewProcessor[MyAppContext, MyOverallContext, MyJobContext](MyAppContext{}, states, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, p.Exec(context.Background(), r))
+
+	require.Len(t, r.Jobs, 1)
+	var job Job[MyJobContext]
+	for _, j := range r.Jobs {
+		job = j
+	}
+	assert.Equal(t, STATE_DONE_TWO, job.State, "should land in FailState after timing out at STATE_MIDDLE")
+
+	// The timeout entry must be keyed on the actual triggering state (MIDDLE),
+	// not TRIGGER_STATE_NEW.
+	assert.Empty(t, job.StateErrors[TRIGGER_STATE_NEW],
+		"NEW transitioned cleanly; should have no error entries")
+	require.Len(t, job.StateErrors[STATE_MIDDLE], 1,
+		"timeout error should be recorded against the state that triggered Exec")
+	assert.Contains(t, job.StateErrors[STATE_MIDDLE][0], "timed out after 50ms")
+}
+
+// TestValidate_RejectsBadConfig confirms that NewProcessor refuses to construct
+// a state machine with a malformed State entry. Covers both pre-existing rules
+// (terminal+negative concurrency, non-terminal+concurrency<1, non-terminal with
+// nil Exec) and Timeout-specific rules (zero/negative Duration, missing or
+// unregistered FailState, Timeout declared on a terminal state).
+func TestValidate_RejectsBadConfig(t *testing.T) {
 	noopExec := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
 		return jc, STATE_DONE, nil, nil
 	}
@@ -1648,6 +1708,32 @@ func TestTimeout_ValidationRejectsBadConfig(t *testing.T) {
 		states []State[MyAppContext, MyOverallContext, MyJobContext]
 		want   string
 	}{
+		// --- pre-existing State invariants ---
+		{
+			name: "terminal state with negative concurrency",
+			states: []State[MyAppContext, MyOverallContext, MyJobContext]{
+				{TriggerState: TRIGGER_STATE_NEW, Exec: noopExec, Concurrency: 1},
+				{TriggerState: STATE_DONE, Terminal: true, Concurrency: -1},
+			},
+			want: "terminal state done has negative concurrency",
+		},
+		{
+			name: "non-terminal state with zero concurrency",
+			states: []State[MyAppContext, MyOverallContext, MyJobContext]{
+				{TriggerState: TRIGGER_STATE_NEW, Exec: noopExec, Concurrency: 0},
+				{TriggerState: STATE_DONE, Terminal: true},
+			},
+			want: "non-terminal state new has non-positive concurrency",
+		},
+		{
+			name: "non-terminal state with nil Exec",
+			states: []State[MyAppContext, MyOverallContext, MyJobContext]{
+				{TriggerState: TRIGGER_STATE_NEW, Exec: nil, Concurrency: 1},
+				{TriggerState: STATE_DONE, Terminal: true},
+			},
+			want: "non-terminal state new but has no Exec function",
+		},
+		// --- Timeout-specific rules ---
 		{
 			name: "zero duration",
 			states: []State[MyAppContext, MyOverallContext, MyJobContext]{

--- a/processor_test.go
+++ b/processor_test.go
@@ -1444,3 +1444,257 @@ func TestProcessor_NoRateLimiterStillWorks(t *testing.T) {
 		t.Errorf("Expected job to be in 'done' state, got '%s'", job.State)
 	}
 }
+
+// --- Timeout tests ---
+
+// timeoutTestStates returns a minimal three-state set used by the timeout tests:
+// a starting state that runs exec, a configurable fail state, and a done state.
+func timeoutTestStates(exec func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error), timeout *Timeout) []State[MyAppContext, MyOverallContext, MyJobContext] {
+	return []State[MyAppContext, MyOverallContext, MyJobContext]{
+		{
+			TriggerState: TRIGGER_STATE_NEW,
+			Exec:         exec,
+			Concurrency:  1,
+			Timeout:      timeout,
+		},
+		{
+			TriggerState: STATE_DONE,
+			Terminal:     true,
+		},
+		{
+			TriggerState: STATE_DONE_TWO,
+			Terminal:     true,
+		},
+	}
+}
+
+// TestTimeout_FiresAndRoutesToFailState verifies that an Exec that exceeds the
+// configured Timeout.Duration is interrupted, the job lands in FailState, and
+// a "timed out after" entry is recorded in StateErrors. The driver respects
+// ctx so the deadline returns promptly rather than running the full sleep.
+func TestTimeout_FiresAndRoutesToFailState(t *testing.T) {
+	t.Parallel()
+
+	exec := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
+		select {
+		case <-time.After(2 * time.Second):
+			return jc, STATE_DONE, nil, nil
+		case <-ctx.Done():
+			return jc, "", nil, ctx.Err()
+		}
+	}
+	states := timeoutTestStates(exec, &Timeout{
+		Duration:  50 * time.Millisecond,
+		FailState: STATE_DONE_TWO,
+	})
+
+	r := NewRun[MyOverallContext, MyJobContext]("timeout-fires", MyOverallContext{})
+	r.AddJob(MyJobContext{})
+
+	p, err := NewProcessor[MyAppContext, MyOverallContext, MyJobContext](MyAppContext{}, states, nil, nil)
+	require.NoError(t, err)
+
+	start := time.Now()
+	require.NoError(t, p.Exec(context.Background(), r))
+	elapsed := time.Since(start)
+
+	require.Len(t, r.Jobs, 1)
+	var job Job[MyJobContext]
+	for _, j := range r.Jobs {
+		job = j
+	}
+	assert.Equal(t, STATE_DONE_TWO, job.State, "should land in configured FailState, not the success target")
+	require.Len(t, job.StateErrors[TRIGGER_STATE_NEW], 1)
+	assert.Contains(t, job.StateErrors[TRIGGER_STATE_NEW][0], "timed out after 50ms")
+	assert.Less(t, elapsed, time.Second, "should fail well before the 2s sleep completes")
+}
+
+// TestTimeout_NotExceededRunsToCompletion verifies that an Exec finishing
+// before the deadline still completes normally and is not misclassified.
+func TestTimeout_NotExceededRunsToCompletion(t *testing.T) {
+	t.Parallel()
+
+	exec := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
+		return jc, STATE_DONE, nil, nil
+	}
+	states := timeoutTestStates(exec, &Timeout{
+		Duration:  5 * time.Second,
+		FailState: STATE_DONE_TWO,
+	})
+
+	r := NewRun[MyOverallContext, MyJobContext]("timeout-no-fire", MyOverallContext{})
+	r.AddJob(MyJobContext{})
+
+	p, err := NewProcessor[MyAppContext, MyOverallContext, MyJobContext](MyAppContext{}, states, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, p.Exec(context.Background(), r))
+
+	for _, j := range r.Jobs {
+		assert.Equal(t, STATE_DONE, j.State)
+		assert.Empty(t, j.StateErrors[TRIGGER_STATE_NEW])
+	}
+}
+
+// TestTimeout_ParentCancelDoesNotMasquerade verifies that cancelling the outer
+// context returned from p.Exec does not surface as a "timed out" classification.
+// The deadline disambiguation in the worker requires the parent ctx to still be
+// healthy at the moment DeadlineExceeded is observed; otherwise the original
+// error must propagate.
+func TestTimeout_ParentCancelDoesNotMasquerade(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	exec := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
+		close(started)
+		select {
+		case <-time.After(5 * time.Second):
+			return jc, STATE_DONE, nil, nil
+		case <-ctx.Done():
+			return jc, "", nil, ctx.Err()
+		}
+	}
+	// A long Timeout so the parent cancel races first.
+	states := timeoutTestStates(exec, &Timeout{
+		Duration:  10 * time.Second,
+		FailState: STATE_DONE_TWO,
+	})
+
+	r := NewRun[MyOverallContext, MyJobContext]("timeout-parent-cancel", MyOverallContext{})
+	r.AddJob(MyJobContext{})
+
+	parentCtx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-started
+		cancel()
+	}()
+
+	p, err := NewProcessor[MyAppContext, MyOverallContext, MyJobContext](MyAppContext{}, states, nil, nil)
+	require.NoError(t, err)
+	// Exec returns the parent ctx error when cancelled mid-run.
+	execErr := p.Exec(parentCtx, r)
+	assert.ErrorIs(t, execErr, context.Canceled)
+
+	// The error logged on the job (if any) must be the original ctx.Canceled,
+	// not a "timed out" reclassification. The worker may also exit before
+	// updating the run, in which case the job stays in TRIGGER_STATE_NEW.
+	for _, j := range r.Jobs {
+		for _, msg := range j.StateErrors[TRIGGER_STATE_NEW] {
+			assert.NotContains(t, msg, "timed out after",
+				"parent cancellation must not surface as a timeout: %q", msg)
+		}
+	}
+}
+
+// TestTimeout_RetryGetsFreshWindow verifies that a state which re-enqueues
+// itself receives a fresh deadline on each attempt. A job that fails three
+// half-deadline attempts and succeeds on the fourth must complete cleanly:
+// each attempt observes the full Timeout.Duration, not a shared one.
+func TestTimeout_RetryGetsFreshWindow(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 200 * time.Millisecond
+	const halfTimeout = timeout / 2
+
+	var mu sync.Mutex
+	attempts := 0
+	exec := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
+		mu.Lock()
+		attempts++
+		n := attempts
+		mu.Unlock()
+		// First three attempts sleep half the deadline (well within budget) and
+		// re-enqueue with an error; the fourth completes.
+		select {
+		case <-time.After(halfTimeout):
+		case <-ctx.Done():
+			return jc, "", nil, ctx.Err()
+		}
+		if n < 4 {
+			return jc, TRIGGER_STATE_NEW, nil, fmt.Errorf("retry %d", n)
+		}
+		return jc, STATE_DONE, nil, nil
+	}
+	states := timeoutTestStates(exec, &Timeout{
+		Duration:  timeout,
+		FailState: STATE_DONE_TWO,
+	})
+
+	r := NewRun[MyOverallContext, MyJobContext]("timeout-fresh-window", MyOverallContext{})
+	r.AddJob(MyJobContext{})
+
+	p, err := NewProcessor[MyAppContext, MyOverallContext, MyJobContext](MyAppContext{}, states, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, p.Exec(context.Background(), r))
+
+	for _, j := range r.Jobs {
+		assert.Equal(t, STATE_DONE, j.State, "fresh deadline per attempt should let retries succeed")
+	}
+	mu.Lock()
+	assert.Equal(t, 4, attempts)
+	mu.Unlock()
+}
+
+// TestTimeout_ValidationRejectsBadConfig confirms that NewProcessor refuses to
+// construct a state machine with a malformed Timeout: zero/negative duration,
+// missing FailState, FailState referencing an unregistered state, or Timeout
+// declared on a terminal state.
+func TestTimeout_ValidationRejectsBadConfig(t *testing.T) {
+	noopExec := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
+		return jc, STATE_DONE, nil, nil
+	}
+
+	cases := []struct {
+		name   string
+		states []State[MyAppContext, MyOverallContext, MyJobContext]
+		want   string
+	}{
+		{
+			name: "zero duration",
+			states: []State[MyAppContext, MyOverallContext, MyJobContext]{
+				{TriggerState: TRIGGER_STATE_NEW, Exec: noopExec, Concurrency: 1, Timeout: &Timeout{Duration: 0, FailState: STATE_DONE}},
+				{TriggerState: STATE_DONE, Terminal: true},
+			},
+			want: "Timeout.Duration must be positive",
+		},
+		{
+			name: "negative duration",
+			states: []State[MyAppContext, MyOverallContext, MyJobContext]{
+				{TriggerState: TRIGGER_STATE_NEW, Exec: noopExec, Concurrency: 1, Timeout: &Timeout{Duration: -time.Second, FailState: STATE_DONE}},
+				{TriggerState: STATE_DONE, Terminal: true},
+			},
+			want: "Timeout.Duration must be positive",
+		},
+		{
+			name: "missing fail state",
+			states: []State[MyAppContext, MyOverallContext, MyJobContext]{
+				{TriggerState: TRIGGER_STATE_NEW, Exec: noopExec, Concurrency: 1, Timeout: &Timeout{Duration: time.Second, FailState: ""}},
+				{TriggerState: STATE_DONE, Terminal: true},
+			},
+			want: "Timeout requires a FailState",
+		},
+		{
+			name: "fail state not registered",
+			states: []State[MyAppContext, MyOverallContext, MyJobContext]{
+				{TriggerState: TRIGGER_STATE_NEW, Exec: noopExec, Concurrency: 1, Timeout: &Timeout{Duration: time.Second, FailState: "ghost"}},
+				{TriggerState: STATE_DONE, Terminal: true},
+			},
+			want: `FailState "ghost" is not a registered state`,
+		},
+		{
+			name: "timeout on terminal state",
+			states: []State[MyAppContext, MyOverallContext, MyJobContext]{
+				{TriggerState: TRIGGER_STATE_NEW, Exec: noopExec, Concurrency: 1},
+				{TriggerState: STATE_DONE, Terminal: true, Timeout: &Timeout{Duration: time.Second, FailState: TRIGGER_STATE_NEW}},
+			},
+			want: "terminal state done cannot define a Timeout",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewProcessor[MyAppContext, MyOverallContext, MyJobContext](MyAppContext{}, tc.states, nil, nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}

--- a/processor_test.go
+++ b/processor_test.go
@@ -1693,11 +1693,45 @@ func TestTimeout_RecordsErrorOnTriggeringState(t *testing.T) {
 	assert.Contains(t, job.StateErrors[STATE_MIDDLE][0], "timed out after 50ms")
 }
 
+// TestTimeout_OnTerminalStateIsIgnored verifies that a Timeout set on a
+// terminal State is permitted at construction and never fires at runtime.
+// This supports flipping a state's Terminal flag during iterative development
+// without having to also strip its Timeout.
+func TestTimeout_OnTerminalStateIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	exec := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
+		return jc, STATE_DONE, nil, nil
+	}
+
+	states := []State[MyAppContext, MyOverallContext, MyJobContext]{
+		{TriggerState: TRIGGER_STATE_NEW, Exec: exec, Concurrency: 1},
+		{
+			TriggerState: STATE_DONE,
+			Terminal:     true,
+			// Inert: STATE_DONE never invokes Exec, so the deadline can't fire.
+			Timeout: &Timeout{Duration: time.Nanosecond, FailState: TRIGGER_STATE_NEW},
+		},
+	}
+
+	r := NewRun[MyOverallContext, MyJobContext]("timeout-on-terminal", MyOverallContext{})
+	r.AddJob(MyJobContext{})
+
+	p, err := NewProcessor[MyAppContext, MyOverallContext, MyJobContext](MyAppContext{}, states, nil, nil)
+	require.NoError(t, err, "Timeout on a terminal state must not be rejected at construction")
+	require.NoError(t, p.Exec(context.Background(), r))
+
+	for _, j := range r.Jobs {
+		assert.Equal(t, STATE_DONE, j.State, "should have reached the terminal state normally")
+		assert.Empty(t, j.StateErrors[STATE_DONE], "no timeout entry should have been recorded against the terminal state")
+	}
+}
+
 // TestValidate_RejectsBadConfig confirms that NewProcessor refuses to construct
 // a state machine with a malformed State entry. Covers both pre-existing rules
 // (terminal+negative concurrency, non-terminal+concurrency<1, non-terminal with
 // nil Exec) and Timeout-specific rules (zero/negative Duration, missing or
-// unregistered FailState, Timeout declared on a terminal state).
+// unregistered FailState).
 func TestValidate_RejectsBadConfig(t *testing.T) {
 	noopExec := func(ctx context.Context, ac MyAppContext, oc MyOverallContext, jc MyJobContext) (MyJobContext, string, []KickRequest[MyJobContext], error) {
 		return jc, STATE_DONE, nil, nil
@@ -1765,14 +1799,6 @@ func TestValidate_RejectsBadConfig(t *testing.T) {
 				{TriggerState: STATE_DONE, Terminal: true},
 			},
 			want: `FailState "ghost" is not a registered state`,
-		},
-		{
-			name: "timeout on terminal state",
-			states: []State[MyAppContext, MyOverallContext, MyJobContext]{
-				{TriggerState: TRIGGER_STATE_NEW, Exec: noopExec, Concurrency: 1},
-				{TriggerState: STATE_DONE, Terminal: true, Timeout: &Timeout{Duration: time.Second, FailState: TRIGGER_STATE_NEW}},
-			},
-			want: "terminal state done cannot define a Timeout",
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Implements the timeout feature you suggested in DM. Per-state Timeout struct with Duration and FailState; per-attempt deadline so retries get fresh windows; parent-cancel disambiguation so outer ctx cancellation isn't misclassified; validation rejects bad config (zero/negative Duration, missing/unregistered FailState, Timeout on terminal state) at NewProcessor.

Tests: 4 behavior cases (timeout fires + routes to FailState, no-fire happy path, parent-cancel doesn't masquerade, retry gets fresh window) plus 1 table-driven validation test (5 sub-cases). Pre-commit hook ran full suite green.